### PR TITLE
Fix server crash when grave is searched by NPC

### DIFF
--- a/server/src/driver/npc.rs
+++ b/server/src/driver/npc.rs
@@ -2368,6 +2368,9 @@ pub fn npc_item_value(in_idx: usize) -> i32 {
         let mut score = 0;
 
         for n in 0..50 {
+            // TODO: Do a deeper dive into what this is doing -- originally
+            // the C code has it.attrib here which is clearly wrong since attrib
+            // only has 5 entries.
             score += it.skill[n][0] * 5;
         }
 


### PR DESCRIPTION
Closes #51 

There was a defect in the original C implementation that ran afoul of memory safety (iterating to the 50th element of an array that only has 5 members). 