### PR TITLE
Add temporary item migration to fix spell and item durations

### DIFF
--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -23,6 +23,27 @@ pub const LEGACY_TICKS: i32 = 18;
 /// Microseconds per tick
 pub const TICK: i64 = 1_000_000 / TICKS as i64;
 
+/// Convert a legacy 18 TPS tick count into the current tick rate.
+///
+/// Uses ceiling division so short-lived timers do not collapse to zero when
+/// scaled to higher TPS values.
+pub const fn scale_legacy_ticks(legacy_ticks: i32) -> i32 {
+    if legacy_ticks <= 0 {
+        return 0;
+    }
+
+    ((legacy_ticks as i64 * TICKS as i64 + LEGACY_TICKS as i64 - 1) / LEGACY_TICKS as i64) as i32
+}
+
+/// `u32` helper variant of [`scale_legacy_ticks`].
+pub const fn scale_legacy_ticks_u32(legacy_ticks: u32) -> u32 {
+    if legacy_ticks == 0 {
+        return 0;
+    }
+
+    ((legacy_ticks as u64 * TICKS as u64 + LEGACY_TICKS as u64 - 1) / LEGACY_TICKS as u64) as u32
+}
+
 /// Server map dimensions
 pub const SERVER_MAPX: i32 = 1024;
 pub const SERVER_MAPY: i32 = 1024;
@@ -933,6 +954,20 @@ mod tests {
 
         // Test empty flags
         assert_eq!(character_flags_name(CharacterFlags::empty()), "UnknownFlag");
+    }
+
+    #[test]
+    fn scale_legacy_ticks_preserves_wall_time_at_36_tps() {
+        assert_eq!(scale_legacy_ticks(180), 360);
+        assert_eq!(scale_legacy_ticks(1), 2);
+        assert_eq!(scale_legacy_ticks(0), 0);
+    }
+
+    #[test]
+    fn scale_legacy_ticks_u32_preserves_wall_time_at_36_tps() {
+        assert_eq!(scale_legacy_ticks_u32(180), 360);
+        assert_eq!(scale_legacy_ticks_u32(1), 2);
+        assert_eq!(scale_legacy_ticks_u32(0), 0);
     }
 
     #[test]

--- a/core/src/constants.rs
+++ b/core/src/constants.rs
@@ -41,7 +41,7 @@ pub const fn scale_legacy_ticks_u32(legacy_ticks: u32) -> u32 {
         return 0;
     }
 
-    ((legacy_ticks as u64 * TICKS as u64 + LEGACY_TICKS as u64 - 1) / LEGACY_TICKS as u64) as u32
+    (legacy_ticks as u64 * TICKS as u64).div_ceil(LEGACY_TICKS as u64) as u32
 }
 
 /// Server map dimensions

--- a/server/src/driver/use_item.rs
+++ b/server/src/driver/use_item.rs
@@ -1155,11 +1155,12 @@ pub fn teleport2(gs: &mut GameState, cn: usize, item_idx: usize) -> bool {
     {
         let spell = &mut gs.items[spell_item];
         let name = b"Teleport";
+        let recall_duration = core::constants::scale_legacy_ticks_u32(180);
         spell.name[..name.len()].copy_from_slice(name);
         spell.flags |= ItemFlags::IF_SPELL.bits();
         spell.sprite[1] = 90;
-        spell.duration = 180;
-        spell.active = 180;
+        spell.duration = recall_duration;
+        spell.active = recall_duration;
         spell.temp = skills::SK_RECALL as u16;
         spell.power = power;
         spell.data[0] = dest_x;
@@ -8045,10 +8046,16 @@ pub fn item_tick_gc(gs: &mut GameState) {
 ///
 /// * Panics if any legacy id or index parameter used by `item_tick` is outside the corresponding game-state collection.
 pub fn item_tick(gs: &mut GameState) {
-    item_tick_expire(gs);
-    item_tick_expire(gs);
-    item_tick_expire(gs);
-    item_tick_expire(gs);
+    // Preserve legacy wall-clock expire pacing (4 passes at 18 TPS) while
+    // allowing arbitrary server tick rates.
+    const LEGACY_EXPIRE_PASSES_PER_TICK: i32 = 4;
+    gs.item_tick_expire_budget += LEGACY_EXPIRE_PASSES_PER_TICK * core::constants::LEGACY_TICKS;
+
+    while gs.item_tick_expire_budget >= core::constants::TICKS {
+        item_tick_expire(gs);
+        gs.item_tick_expire_budget -= core::constants::TICKS;
+    }
+
     item_tick_gc(gs);
 }
 

--- a/server/src/game_state.rs
+++ b/server/src/game_state.rs
@@ -1,7 +1,8 @@
 use crate::path_finding::PathFinder;
 use crate::types::server_player::ServerPlayer;
-use core::constants::{CharacterFlags, USE_EMPTY};
+use core::constants::{CharacterFlags, ItemFlags, USE_EMPTY};
 use core::talent_trees::total_points_spent;
+use redis::Commands;
 use std::collections::HashMap;
 
 /// Runtime state for the Harakim Element Switching passive.
@@ -87,6 +88,12 @@ pub struct GameState {
     pub item_tick_gc_count: u32,
     /// Item tick expiration counter.
     pub item_tick_expire_counter: u32,
+    /// Carry-over budget for legacy item-expire passes.
+    ///
+    /// Legacy item expiration was authored around 18 TPS with 4 expire passes
+    /// per game tick. This accumulator allows us to preserve that same
+    /// wall-clock pacing at any current `TICKS` value.
+    pub item_tick_expire_budget: i32,
 
     // -- Visibility state (formerly State) --
     /// Scratch visibility buffer (underscore prefix preserved from original).
@@ -139,6 +146,8 @@ pub struct GameState {
 }
 
 impl GameState {
+    const TIMER_MIGRATION_KEY: &'static str = "game:meta:timers_migrated_v1";
+
     /// Normalize MOTD text for safe client display.
     ///
     /// Applies the historical maximum length constraint to avoid client
@@ -199,6 +208,7 @@ impl GameState {
             item_tick_gc_off: 0,
             item_tick_gc_count: 0,
             item_tick_expire_counter: 0,
+            item_tick_expire_budget: 0,
             // Visibility state
             _visi: [0; core::constants::VISI_BUFFER_LEN],
             visi: [0; core::constants::VISI_BUFFER_LEN],
@@ -282,7 +292,9 @@ impl GameState {
     /// * `Err(String)` if the KeyDB connection or load fails.
     fn load_from_keydb(&mut self) -> Result<(), String> {
         let mut con = keydb::connect()?;
-        let data = store::load_all(&mut con)?;
+        let mut data = store::load_all(&mut con)?;
+
+        self.migrate_legacy_timer_data_once(&mut con, &mut data)?;
 
         self.map = data.map;
         self.items = data.items;
@@ -309,6 +321,118 @@ impl GameState {
         );
 
         Ok(())
+    }
+
+    /// Performs a one-time migration that rescales persisted legacy spell/item
+    /// countdown timers from 18 TPS units to current TPS units.
+    ///
+    /// # Arguments
+    ///
+    /// * `con` - Open KeyDB connection used to read/write migration marker.
+    /// * `data` - Loaded snapshot data that may need timer normalization.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` if migration is complete or already applied.
+    /// * `Err(String)` if marker read/write fails.
+    fn migrate_legacy_timer_data_once(
+        &self,
+        con: &mut redis::Connection,
+        data: &mut store::GameData,
+    ) -> Result<(), String> {
+        let already_migrated: bool = con
+            .exists(Self::TIMER_MIGRATION_KEY)
+            .map_err(|e| format!("KeyDB EXISTS {}: {e}", Self::TIMER_MIGRATION_KEY))?;
+
+        if already_migrated {
+            return Ok(());
+        }
+
+        let runtime_count = Self::normalize_legacy_runtime_item_timers(&mut data.items);
+        let template_count = Self::normalize_legacy_spell_template_timers(&mut data.item_templates);
+
+        con.set::<_, _, ()>(Self::TIMER_MIGRATION_KEY, 1)
+            .map_err(|e| format!("KeyDB SET {}: {e}", Self::TIMER_MIGRATION_KEY))?;
+
+        log::info!(
+            "Applied timer migration v1: normalized {} runtime items and {} item templates",
+            runtime_count,
+            template_count
+        );
+
+        Ok(())
+    }
+
+    /// Normalizes runtime item timers that represent active countdown-based spell effects.
+    ///
+    /// # Arguments
+    ///
+    /// * `items` - Runtime item slots to normalize in-place.
+    ///
+    /// # Returns
+    ///
+    /// * Number of items modified.
+    pub(crate) fn normalize_legacy_runtime_item_timers(items: &mut [core::types::Item]) -> usize {
+        let mut changed = 0usize;
+
+        for item in items.iter_mut() {
+            if item.used == USE_EMPTY {
+                continue;
+            }
+            if (item.flags & ItemFlags::IF_SPELL.bits()) == 0 {
+                continue;
+            }
+
+            let mut item_changed = false;
+
+            if item.duration > 0 {
+                item.duration = core::constants::scale_legacy_ticks_u32(item.duration);
+                item_changed = true;
+            }
+
+            if item.active > 0 && item.active != u32::MAX {
+                item.active = core::constants::scale_legacy_ticks_u32(item.active);
+                item_changed = true;
+            }
+
+            if item_changed {
+                changed += 1;
+            }
+        }
+
+        changed
+    }
+
+    /// Normalizes spell-related item-template timers from legacy 18 TPS units.
+    ///
+    /// # Arguments
+    ///
+    /// * `item_templates` - Item templates to normalize in-place.
+    ///
+    /// # Returns
+    ///
+    /// * Number of templates modified.
+    pub(crate) fn normalize_legacy_spell_template_timers(
+        item_templates: &mut [core::types::Item],
+    ) -> usize {
+        let mut changed = 0usize;
+
+        for template in item_templates.iter_mut() {
+            if template.used == USE_EMPTY {
+                continue;
+            }
+            if (template.flags & ItemFlags::IF_SPELL.bits()) == 0 {
+                continue;
+            }
+            if template.duration == 0 {
+                continue;
+            }
+
+            template.duration = core::constants::scale_legacy_ticks_u32(template.duration);
+            changed += 1;
+        }
+
+        changed
     }
 
     /// Mark loaded characters with learned talents for one stat recompute.
@@ -426,5 +550,50 @@ mod tests {
     fn normalize_motd_empty() {
         let result = GameState::normalize_message_of_the_day(String::new());
         assert_eq!(result, "");
+    }
+
+    #[test]
+    fn normalize_legacy_runtime_item_timers_scales_spell_items_only() {
+        let mut items = vec![core::types::Item::default(); 4];
+
+        items[1].used = core::constants::USE_ACTIVE;
+        items[1].flags = core::constants::ItemFlags::IF_SPELL.bits();
+        items[1].duration = 180;
+        items[1].active = 90;
+
+        items[2].used = core::constants::USE_ACTIVE;
+        items[2].duration = 180;
+        items[2].active = 90;
+
+        items[3].used = core::constants::USE_ACTIVE;
+        items[3].flags = core::constants::ItemFlags::IF_SPELL.bits();
+        items[3].duration = 0;
+        items[3].active = u32::MAX;
+
+        let changed = GameState::normalize_legacy_runtime_item_timers(&mut items);
+        assert_eq!(changed, 1);
+        assert_eq!(items[1].duration, 360);
+        assert_eq!(items[1].active, 180);
+        assert_eq!(items[2].duration, 180);
+        assert_eq!(items[2].active, 90);
+        assert_eq!(items[3].duration, 0);
+        assert_eq!(items[3].active, u32::MAX);
+    }
+
+    #[test]
+    fn normalize_legacy_spell_template_timers_scales_spell_templates_only() {
+        let mut templates = vec![core::types::Item::default(); 3];
+
+        templates[1].used = core::constants::USE_ACTIVE;
+        templates[1].flags = core::constants::ItemFlags::IF_SPELL.bits();
+        templates[1].duration = 180;
+
+        templates[2].used = core::constants::USE_ACTIVE;
+        templates[2].duration = 180;
+
+        let changed = GameState::normalize_legacy_spell_template_timers(&mut templates);
+        assert_eq!(changed, 1);
+        assert_eq!(templates[1].duration, 360);
+        assert_eq!(templates[2].duration, 180);
     }
 }

--- a/server/src/game_state.rs
+++ b/server/src/game_state.rs
@@ -348,6 +348,7 @@ impl GameState {
             return Ok(());
         }
 
+        // TODO: We will eventually want to take this migration out once we are updating the templates
         let runtime_count = Self::normalize_legacy_runtime_item_timers(&mut data.items);
         let template_count = Self::normalize_legacy_spell_template_timers(&mut data.item_templates);
 

--- a/server/src/god.rs
+++ b/server/src/god.rs
@@ -79,32 +79,37 @@ impl God {
         backup_x: usize,
         backup_y: usize,
     ) -> bool {
+        let x_m1 = x.saturating_sub(1);
+        let x_m2 = x.saturating_sub(2);
+        let y_m1 = y.saturating_sub(1);
+        let y_m2 = y.saturating_sub(2);
+
         let positions_to_try: [(usize, usize); 25] = [
             (x, y),
             (x + 1, y),
-            (x - 1, y),
+            (x_m1, y),
             (x, y + 1),
-            (x, y - 1),
+            (x, y_m1),
             (x + 1, y + 1),
-            (x + 1, y - 1),
-            (x - 1, y + 1),
-            (x - 1, y - 1),
-            (x + 2, y - 2),
-            (x + 2, y - 1),
+            (x + 1, y_m1),
+            (x_m1, y + 1),
+            (x_m1, y_m1),
+            (x + 2, y_m2),
+            (x + 2, y_m1),
             (x + 2, y),
             (x + 2, y + 1),
             (x + 2, y + 2),
-            (x - 2, y - 2),
-            (x - 2, y - 1),
-            (x - 2, y),
-            (x - 2, y + 1),
-            (x - 2, y + 2),
-            (x - 1, y + 2),
+            (x_m2, y_m2),
+            (x_m2, y_m1),
+            (x_m2, y),
+            (x_m2, y + 1),
+            (x_m2, y + 2),
+            (x_m1, y + 2),
             (x, y + 2),
             (x + 1, y + 2),
-            (x - 1, y - 2),
-            (x, y - 2),
-            (x + 1, y - 2),
+            (x_m1, y_m2),
+            (x, y_m2),
+            (x + 1, y_m2),
         ];
 
         for (try_x, try_y) in positions_to_try.iter() {
@@ -329,8 +334,13 @@ impl God {
         character.goto_x = x as u16;
         character.goto_y = y as u16; // TODO: This was missing before... should this be here?
 
-        let positions_to_try: [(usize, usize); 5] =
-            [(x, y), (x + 3, y), (x, y + 3), (x - 3, y), (x, y - 3)];
+        let positions_to_try: [(usize, usize); 5] = [
+            (x, y),
+            (x + 3, y),
+            (x, y + 3),
+            (x.saturating_sub(3), y),
+            (x, y.saturating_sub(3)),
+        ];
 
         for (try_x, try_y) in positions_to_try.iter() {
             if Self::drop_char_fuzzy_large(gs, character_id, *try_x, *try_y, x, y) {
@@ -354,32 +364,37 @@ impl God {
     ///
     /// * `true` when `drop_char_fuzzy` succeeds or the condition is met, otherwise `false`.
     pub fn drop_char_fuzzy(gs: &mut GameState, character_id: usize, x: usize, y: usize) -> bool {
+        let x_m1 = x.saturating_sub(1);
+        let x_m2 = x.saturating_sub(2);
+        let y_m1 = y.saturating_sub(1);
+        let y_m2 = y.saturating_sub(2);
+
         let positions_to_try: [(usize, usize); 25] = [
             (x, y),
             (x + 1, y),
-            (x - 1, y),
+            (x_m1, y),
             (x, y + 1),
-            (x, y - 1),
+            (x, y_m1),
             (x + 1, y + 1),
-            (x + 1, y - 1),
-            (x - 1, y + 1),
-            (x - 1, y - 1),
-            (x + 2, y - 2),
-            (x + 2, y - 1),
+            (x + 1, y_m1),
+            (x_m1, y + 1),
+            (x_m1, y_m1),
+            (x + 2, y_m2),
+            (x + 2, y_m1),
             (x + 2, y),
             (x + 2, y + 1),
             (x + 2, y + 2),
-            (x - 2, y - 2),
-            (x - 2, y - 1),
-            (x - 2, y),
-            (x - 2, y + 1),
-            (x - 2, y + 2),
-            (x - 1, y + 2),
+            (x_m2, y_m2),
+            (x_m2, y_m1),
+            (x_m2, y),
+            (x_m2, y + 1),
+            (x_m2, y + 2),
+            (x_m1, y + 2),
             (x, y + 2),
             (x + 1, y + 2),
-            (x - 1, y - 2),
-            (x, y - 2),
-            (x + 1, y - 2),
+            (x_m1, y_m2),
+            (x, y_m2),
+            (x + 1, y_m2),
         ];
 
         for (try_x, try_y) in positions_to_try.iter() {
@@ -1069,6 +1084,20 @@ impl God {
 
         let character = &gs.characters[cn];
         let (current_x, current_y) = (character.x as usize, character.y as usize);
+        let max_x = i64::from(core::constants::SERVER_MAPX - 2);
+        let max_y = i64::from(core::constants::SERVER_MAPY - 2);
+
+        let parse_len = |axis: &str| -> Option<i64> {
+            cy.parse::<i64>().map(Some).unwrap_or_else(|_| {
+                log::error!(
+                    "Failed to parse {} coordinate '{}' in goto command for character {}",
+                    axis,
+                    cy,
+                    cn
+                );
+                None
+            })
+        };
 
         // North - decrease x
         // South - increase x
@@ -1076,58 +1105,24 @@ impl God {
         // West  - decrease y
         let (target_x, target_y) = match cx.to_lowercase().as_str() {
             "n" => {
-                if let Ok(val) = cy.parse::<i32>() {
-                    let new_x = (current_x as i32 - val).max(1) as usize;
-                    (new_x, current_y)
-                } else {
-                    log::error!(
-                        "Failed to parse X coordinate '{}' in goto command for character {}",
-                        cy,
-                        cn
-                    );
-                    return None;
-                }
+                let val = parse_len("X")?;
+                let new_x = ((current_x as i64) - val).clamp(1, max_x) as usize;
+                (new_x, current_y)
             }
             "s" => {
-                if let Ok(val) = cy.parse::<i32>() {
-                    let new_x =
-                        (current_x as i32 + val).min(core::constants::SERVER_MAPX - 2) as usize;
-                    (new_x, current_y)
-                } else {
-                    log::error!(
-                        "Failed to parse X coordinate '{}' in goto command for character {}",
-                        cy,
-                        cn
-                    );
-                    return None;
-                }
+                let val = parse_len("X")?;
+                let new_x = ((current_x as i64) + val).clamp(1, max_x) as usize;
+                (new_x, current_y)
             }
             "e" => {
-                if let Ok(val) = cy.parse::<i32>() {
-                    let new_y =
-                        (current_y as i32 + val).min(core::constants::SERVER_MAPY - 2) as usize;
-                    (current_x, new_y)
-                } else {
-                    log::error!(
-                        "Failed to parse Y coordinate '{}' in goto command for character {}",
-                        cy,
-                        cn
-                    );
-                    return None;
-                }
+                let val = parse_len("Y")?;
+                let new_y = ((current_y as i64) + val).clamp(1, max_y) as usize;
+                (current_x, new_y)
             }
             "w" => {
-                if let Ok(val) = cy.parse::<i32>() {
-                    let new_y = (current_y as i32 - val).max(1) as usize;
-                    (current_x, new_y)
-                } else {
-                    log::error!(
-                        "Failed to parse Y coordinate '{}' in goto command for character {}",
-                        cy,
-                        cn
-                    );
-                    return None;
-                }
+                let val = parse_len("Y")?;
+                let new_y = ((current_y as i64) - val).clamp(1, max_y) as usize;
+                (current_x, new_y)
             }
             _ => {
                 log::error!(
@@ -5111,5 +5106,76 @@ impl God {
                 targets.len()
             ),
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::God;
+    use crate::test_helpers::{add_test_player, with_test_gs};
+
+    #[test]
+    fn goto_cardinal_north_clamps_to_one() {
+        with_test_gs(|gs| {
+            let (cn, _) = add_test_player(gs);
+            gs.characters[cn].x = 90;
+            gs.characters[cn].y = 110;
+
+            let target = God::goto_cardinal_length(gs, cn, "n", "100");
+            assert_eq!(target, Some((1, 110)));
+        });
+    }
+
+    #[test]
+    fn goto_cardinal_south_clamps_to_map_max() {
+        with_test_gs(|gs| {
+            let (cn, _) = add_test_player(gs);
+            gs.characters[cn].x = 90;
+            gs.characters[cn].y = 110;
+
+            let target = God::goto_cardinal_length(gs, cn, "s", "2147483647");
+            assert_eq!(
+                target,
+                Some(((core::constants::SERVER_MAPX - 2) as usize, 110))
+            );
+        });
+    }
+
+    #[test]
+    fn goto_cardinal_east_clamps_to_map_max() {
+        with_test_gs(|gs| {
+            let (cn, _) = add_test_player(gs);
+            gs.characters[cn].x = 90;
+            gs.characters[cn].y = 110;
+
+            let target = God::goto_cardinal_length(gs, cn, "e", "2147483647");
+            assert_eq!(
+                target,
+                Some((90, (core::constants::SERVER_MAPY - 2) as usize))
+            );
+        });
+    }
+
+    #[test]
+    fn goto_cardinal_west_clamps_to_one() {
+        with_test_gs(|gs| {
+            let (cn, _) = add_test_player(gs);
+            gs.characters[cn].x = 90;
+            gs.characters[cn].y = 110;
+
+            let target = God::goto_cardinal_length(gs, cn, "w", "2147483647");
+            assert_eq!(target, Some((90, 1)));
+        });
+    }
+
+    #[test]
+    fn transfer_char_does_not_panic_near_map_edge() {
+        with_test_gs(|gs| {
+            let (cn, _) = add_test_player(gs);
+            gs.characters[cn].x = 2;
+            gs.characters[cn].y = 100;
+
+            let _ = God::transfer_char(gs, cn, 1, 100);
+        });
     }
 }

--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -1191,11 +1191,13 @@ impl Server {
 
         if req.reload_items {
             match server::keydb::store::load_item_templates(&mut con) {
-                Ok(items) => {
+                Ok(mut items) => {
+                    let migrated = GameState::normalize_legacy_spell_template_timers(&mut items);
                     log::info!(
-                        "template reload {}: swapped {} item templates",
+                        "template reload {}: swapped {} item templates (normalized {} spell timers)",
                         req.request_id,
-                        items.len()
+                        items.len(),
+                        migrated,
                     );
                     gs.item_templates = items;
                 }


### PR DESCRIPTION
Eventually this will need to be undone once we update the templates